### PR TITLE
Use io.Reader to load TaskLists

### DIFF
--- a/common.go
+++ b/common.go
@@ -8,6 +8,16 @@ var (
 	oneDay      = 24 * time.Hour
 )
 
+// ignoreLine uses the IgnoreComments variable and the presence of
+//      a '#' to detect if a line should be ignored. Empty lines are
+//      ignored automatically.
+func ignoreLine(line string) bool {
+    return isEmpty(line) || (
+        IgnoreComments && 
+        strings.HasPrefix(line, "#")
+    )
+}
+
 // isEmpty checks if the string is empty.
 func isEmpty(s string) bool {
 	return len(s) == 0

--- a/common.go
+++ b/common.go
@@ -1,6 +1,9 @@
 package todotxt
 
-import "time"
+import (
+    "strings"
+    "time"
+)
 
 var (
 	emptyStr    string
@@ -12,10 +15,12 @@ var (
 //      a '#' to detect if a line should be ignored. Empty lines are
 //      ignored automatically.
 func ignoreLine(line string) bool {
-    return isEmpty(line) || (
-        IgnoreComments && 
-        strings.HasPrefix(line, "#")
-    )
+    if isEmpty(line) {
+        return true
+    } else if IgnoreComments && strings.HasPrefix(line, "#") {
+        return true
+    }
+    return false
 }
 
 // isEmpty checks if the string is empty.

--- a/common.go
+++ b/common.go
@@ -1,27 +1,12 @@
 package todotxt
 
-import (
-    "strings"
-    "time"
-)
+import "time"
 
 var (
 	emptyStr    string
 	whitespaces = "\t\n\r "
 	oneDay      = 24 * time.Hour
 )
-
-// ignoreLine uses the IgnoreComments variable and the presence of
-//      a '#' to detect if a line should be ignored. Empty lines are
-//      ignored automatically.
-func ignoreLine(line string) bool {
-    if isEmpty(line) {
-        return true
-    } else if IgnoreComments && strings.HasPrefix(line, "#") {
-        return true
-    }
-    return false
-}
 
 // isEmpty checks if the string is empty.
 func isEmpty(s string) bool {

--- a/task.go
+++ b/task.go
@@ -113,6 +113,10 @@ func (task Task) String() string {
 
 // ParseTask parses the input text string into a Task struct.
 func ParseTask(text string) (*Task, error) {
+    if ignoreLine(text) {
+        return nil, nil
+    }
+
 	var err error
 
 	oriText := strings.Trim(text, whitespaces)

--- a/task.go
+++ b/task.go
@@ -113,7 +113,9 @@ func (task Task) String() string {
 
 // ParseTask parses the input text string into a Task struct.
 func ParseTask(text string) (*Task, error) {
-    if ignoreLine(text) {
+    // bail out early by returning a nil pointer
+    //      if there is no task to create
+    if isEmpty(text) || (IgnoreComments && strings.HasPrefix(text, "#"))  {
         return nil, nil
     }
 

--- a/todotxt.go
+++ b/todotxt.go
@@ -108,12 +108,12 @@ func (tasklist *TaskList) RemoveTask(task Task) error {
 	return nil
 }
 
-// LoadFrom loads a TaskList from an *io.Reader
+// LoadFrom loads a TaskList from an io.Reader
 //
 // os.File and os.Stdin are interfaces that include io.Reader, which is also bufio.Scanner's input type
 //
 // Note: This will clear the current TaskList and replace its contents with the reader's output.
-func (tasklist *TaskList) LoadFrom(tasks *io.Reader) error {
+func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 	*tasklist = []Task{} // Empty task list
 
 	taskID := 1
@@ -177,7 +177,7 @@ func (tasklist *TaskList) WriteToPath(filename string) error {
 	return ioutil.WriteFile(filename, []byte(tasklist.String()), 0640)
 }
 
-func LoadFrom(todos *io.Reader) (TaskList, error) {
+func LoadFrom(todos io.Reader) (TaskList, error) {
 	tasklist := TaskList{}
 	if err := tasklist.LoadFrom(todos); err != nil {
 		return nil, err

--- a/todotxt.go
+++ b/todotxt.go
@@ -118,6 +118,9 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 
 	taskID := 1
 	scanner := bufio.NewScanner(tasks)
+
+    // scan in each line
+    var scanErr error
 	for scanner.Scan() {
 		text := strings.Trim(scanner.Text(), whitespaces) // Read line
 
@@ -128,7 +131,8 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 		task, err := ParseTask(text)
 
 		if err != nil {
-			return err
+            scanErr = err
+            break
 		}
 
 		task.ID = taskID
@@ -137,8 +141,7 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 		taskID++
 	}
 
-    // if everything ran as expected, this will be nil
-	return scanner.Err()
+	return scanErr || scanner.Err()
 }
 
 // LoadFromFile loads a TaskList from *os.File using LoadFrom

--- a/todotxt.go
+++ b/todotxt.go
@@ -121,21 +121,23 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 	for scanner.Scan() {
 		text := strings.Trim(scanner.Text(), whitespaces) // Read line
 
-		// Ignore blank or comment lines
-		if isEmpty(text) || (IgnoreComments && strings.HasPrefix(text, "#")) {
+		if ignoreLine(text) { 
 			continue
 		}
 
 		task, err := ParseTask(text)
+
 		if err != nil {
 			return err
 		}
+
 		task.ID = taskID
 
 		*tasklist = append(*tasklist, *task)
 		taskID++
 	}
 
+    // if everything ran as expected, this will be nil
 	return scanner.Err()
 }
 
@@ -177,9 +179,10 @@ func (tasklist *TaskList) WriteToPath(filename string) error {
 	return ioutil.WriteFile(filename, []byte(tasklist.String()), 0640)
 }
 
+// LoadFrom creates and returns a new TaskList
 func LoadFrom(todos io.Reader) (TaskList, error) {
-	tasklist := TaskList{}
-	if err := tasklist.LoadFrom(todos); err != nil {
+	newTaskList := TaskList{}
+	if err := newTaskList.LoadFrom(todos); err != nil {
 		return nil, err
 	}
 	return tasklist, nil

--- a/todotxt.go
+++ b/todotxt.go
@@ -120,20 +120,16 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 	scanner := bufio.NewScanner(tasks)
 
     // scan in each line
-    var scanErr error
 	for scanner.Scan() {
 		text := strings.Trim(scanner.Text(), whitespaces) // Read line
-
-		if ignoreLine(text) { 
-			continue
-		}
-
 		task, err := ParseTask(text)
 
 		if err != nil {
-            scanErr = err
-            break
-		}
+            return err
+		} else if task == nil {
+            // if task pointer is empty do not create task
+            continue 
+        }
 
 		task.ID = taskID
 
@@ -141,7 +137,7 @@ func (tasklist *TaskList) LoadFrom(tasks io.Reader) error {
 		taskID++
 	}
 
-	return scanErr || scanner.Err()
+	return scanner.Err()
 }
 
 // LoadFromFile loads a TaskList from *os.File using LoadFrom

--- a/todotxt.go
+++ b/todotxt.go
@@ -108,12 +108,12 @@ func (tasklist *TaskList) RemoveTask(task Task) error {
 	return nil
 }
 
-// LoadFromReader loads a TaskList from an *io.Reader
+// LoadFrom loads a TaskList from an *io.Reader
 //
 // os.File and os.Stdin are interfaces that include io.Reader, which is also bufio.Scanner's input type
 //
 // Note: This will clear the current TaskList and replace its contents with the reader's output.
-func (tasklist *TaskList) LoadFromReader(tasks *io.Reader) error {
+func (tasklist *TaskList) LoadFrom(tasks *io.Reader) error {
 	*tasklist = []Task{} // Empty task list
 
 	taskID := 1
@@ -139,10 +139,10 @@ func (tasklist *TaskList) LoadFromReader(tasks *io.Reader) error {
 	return scanner.Err()
 }
 
-// LoadFromFile loads a TaskList from *os.File using LoadFromReader
+// LoadFromFile loads a TaskList from *os.File using LoadFrom
 func (tasklist *TaskList) LoadFromFile(file *os.File) error {
 	// passthrough method to generic form
-	return tasklist.LoadFromReader(file)
+	return tasklist.LoadFrom(file)
 }
 
 // LoadFromPath loads a TaskList from a file (most likely called "todo.txt").
@@ -153,14 +153,17 @@ func (tasklist *TaskList) LoadFromPath(filename string) error {
 	}
 	defer file.Close()
 
-	return tasklist.LoadFromReader(file)
+	return tasklist.LoadFrom(file)
 }
 
-// WriteToFile writes a TaskList to *os.File.
+// WriteTo
 //
 // Using *os.File instead of a filename allows to also use os.Stdout.
 //
 // Note: Comments from original file will be omitted and not written to target *os.File, if IgnoreComments is set to 'true'.
+
+// WriteToFile writes a TaskList to *os.File.
+//
 func (tasklist *TaskList) WriteToFile(file *os.File) error {
 	writer := bufio.NewWriter(file)
 	if _, err := writer.WriteString(tasklist.String()); err != nil {
@@ -174,15 +177,18 @@ func (tasklist *TaskList) WriteToPath(filename string) error {
 	return ioutil.WriteFile(filename, []byte(tasklist.String()), 0640)
 }
 
-// LoadFromFile loads and returns a TaskList from *os.File.
-//
-// Using *os.File instead of a filename allows to also use os.Stdin.
-func LoadFromFile(file *os.File) (TaskList, error) {
+func LoadFrom(todos *io.Reader) (TaskList, error) {
 	tasklist := TaskList{}
-	if err := tasklist.LoadFromFile(file); err != nil {
+	if err := tasklist.LoadFrom(todos); err != nil {
 		return nil, err
 	}
 	return tasklist, nil
+}
+
+// LoadFromFile creates a new TaskList and loads it from an *os.File using TaskList.LoadFrom
+func LoadFromFile(file *os.File) (TaskList, error) {
+	// passthrough to generic function
+	return LoadFrom(file)
 }
 
 // WriteToFile writes a TaskList to *os.File.

--- a/todotxt.go
+++ b/todotxt.go
@@ -184,7 +184,7 @@ func LoadFrom(todos io.Reader) (TaskList, error) {
 	if err := newTaskList.LoadFrom(todos); err != nil {
 		return nil, err
 	}
-	return tasklist, nil
+	return newTaskList, nil
 }
 
 // LoadFromFile creates a new TaskList and loads it from an *os.File using TaskList.LoadFrom


### PR DESCRIPTION
[`io.Reader`](https://pkg.go.dev/io#Reader) is an interface definition that is met by anything that has a `.Read()` method.

A generic `ReadFrom` method that takes an `io.Reader` has been added to `TaskList`. Also slightly refactored the read methods in the process of redirecting existing functions to the generic versions.