### PR TITLE
fix: "errcheck" lint error

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func BenchmarkTaskList_Filter(b *testing.B) {
-	testTasklist.LoadFromPath(testInputFilter)
+	if err := testTasklist.LoadFromPath(testInputFilter); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = testTasklist.Filter(FilterNot(FilterCompleted)).Filter(FilterByPriority("A"), FilterByPriority("B"))

--- a/sort_test.go
+++ b/sort_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func BenchmarkTaskList_Sort(b *testing.B) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = testTasklist.Sort(SortPriorityAsc, SortCreatedDateAsc, SortTodoTextDesc)
@@ -41,7 +44,10 @@ func TestTaskSortByType(t *testing.T) {
 }
 
 func TestTaskSortByPriority(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 0
 
 	testTasklist = testTasklist[taskID : taskID+6]
@@ -74,7 +80,10 @@ func TestTaskSortByPriority(t *testing.T) {
 }
 
 func TestTaskSortByCreatedDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 6
 
 	testTasklist = testTasklist[taskID : taskID+5]
@@ -105,7 +114,10 @@ func TestTaskSortByCreatedDate(t *testing.T) {
 }
 
 func TestTaskSortByCompletedDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 11
 
 	testTasklist = testTasklist[taskID : taskID+6]
@@ -138,7 +150,10 @@ func TestTaskSortByCompletedDate(t *testing.T) {
 }
 
 func TestTaskSortByDueDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 17
 
 	testTasklist = testTasklist[taskID : taskID+4]
@@ -167,7 +182,10 @@ func TestTaskSortByDueDate(t *testing.T) {
 }
 
 func TestTaskSortByTaskID(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 21
 
 	testTasklist = testTasklist[taskID : taskID+5]
@@ -202,7 +220,10 @@ func TestTaskSortByTaskID(t *testing.T) {
 }
 
 func TestTaskSortByContext(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 26
 
 	testTasklist = testTasklist[taskID : taskID+6]
@@ -239,7 +260,10 @@ func TestTaskSortByContext(t *testing.T) {
 }
 
 func TestTaskSortByProject(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 32
 
 	testTasklist = testTasklist[taskID : taskID+6]
@@ -276,7 +300,10 @@ func TestTaskSortByProject(t *testing.T) {
 }
 
 func TestTaskSortByTodoText(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 38
 
 	testTasklist = testTasklist[taskID : taskID+5]
@@ -307,7 +334,10 @@ func TestTaskSortByTodoText(t *testing.T) {
 }
 
 func TestTaskSortByMultipleFlags(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 43
 
 	testTasklist = testTasklist[taskID : taskID+7]
@@ -370,7 +400,9 @@ func TestTaskSortByMultipleFlags(t *testing.T) {
 }
 
 func TestTaskSortError(t *testing.T) {
-	testTasklist.LoadFromPath(testInputSort)
+	if err := testTasklist.LoadFromPath(testInputSort); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := testTasklist.Sort(123); err == nil {
 		t.Errorf("Expected Sort() to fail because of unrecognized sort option, but it didn't!")

--- a/task_test.go
+++ b/task_test.go
@@ -215,7 +215,9 @@ func TestParseTask(t *testing.T) {
 }
 
 func TestTaskID(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
 
 	taskID := 1
 	testGot = testTasklist[taskID-1].ID
@@ -237,7 +239,10 @@ func TestTaskID(t *testing.T) {
 }
 
 func TestTaskString(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 1
 
 	testExpected = "2013-02-22 Pick up milk @GroceryStore"
@@ -276,7 +281,10 @@ func TestTaskString(t *testing.T) {
 }
 
 func TestTaskPriority(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 6
 
 	testExpected = "B"
@@ -306,7 +314,10 @@ func TestTaskPriority(t *testing.T) {
 }
 
 func TestTaskCreatedDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 10
 
 	testExpected, err := parseTime("2012-01-30")
@@ -365,7 +376,10 @@ func TestTaskCreatedDate(t *testing.T) {
 }
 
 func TestTaskContexts(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 16
 
 	testExpected = []string{"Call", "Phone"}
@@ -397,7 +411,10 @@ func TestTaskContexts(t *testing.T) {
 }
 
 func TestTasksProjects(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 20
 
 	testExpected = []string{"Gardening", "Improving", "Planning", "Relaxing-Work"}
@@ -422,7 +439,10 @@ func TestTasksProjects(t *testing.T) {
 }
 
 func TestTaskDueDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 23
 
 	testExpected, err := parseTime("2014-02-17")
@@ -486,7 +506,10 @@ func TestTaskDueDate(t *testing.T) {
 }
 
 func TestTaskAddonTags(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 25
 
 	testExpected = map[string]string{"Level": "5", "private": "false"}
@@ -522,7 +545,10 @@ func TestTaskAddonTags(t *testing.T) {
 }
 
 func TestTaskIsCompleted(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	var (
 		taskID   int
 		testGot1 bool
@@ -545,7 +571,10 @@ func TestTaskIsCompleted(t *testing.T) {
 }
 
 func TestTaskCompleted(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 29
 
 	testExpected = true
@@ -584,7 +613,10 @@ func TestTaskCompleted(t *testing.T) {
 }
 
 func TestTaskCompletedDate(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 34
 
 	if testTasklist[taskID-1].HasCompletedDate() {
@@ -633,7 +665,10 @@ func TestTaskCompletedDate(t *testing.T) {
 }
 
 func TestTaskIsOverdue(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 40
 
 	testGot = testTasklist[taskID-1].IsOverdue()
@@ -678,7 +713,10 @@ func TestTaskIsOverdue(t *testing.T) {
 }
 
 func TestTaskComplete(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 44
 
 	// first 4 tasks should all match the same tests
@@ -736,7 +774,10 @@ func TestTaskComplete(t *testing.T) {
 }
 
 func TestTaskReopen(t *testing.T) {
-	testTasklist.LoadFromPath(testInputTask)
+	if err := testTasklist.LoadFromPath(testInputTask); err != nil {
+		t.Fatal(err)
+	}
+
 	taskID := 49
 
 	// the first 2 tasks should match the same tests


### PR DESCRIPTION
Nothing special. It only adds the "returned error check" from `testTasklist.LoadFromPath()` in the tests.

It will fix the static analysis errors of [`errcheck` from golangci-lint](https://golangci-lint.run/usage/linters/).
It should bring up the coverage back to 100% as well.

